### PR TITLE
Added devcontainer support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+  "name": "Pure.RelationalSchema.Self.Schema",
+  "image": "mcr.microsoft.com/devcontainers/dotnet:10.0-noble",
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-dotnettools.csdevkit",
+        "ms-dotnettools.csharp",
+        "ms-dotnettools.vscode-dotnet-runtime",
+        "editorconfig.editorconfig"
+      ],
+      "settings": { "editor.formatOnSave": true }
+    }
+  },
+  "postCreateCommand": "cd src && dotnet restore && dotnet tool install -g dotnet-stryker",
+  "remoteUser": "vscode"
+}


### PR DESCRIPTION
## What
Adds `.devcontainer/devcontainer.json` so this repo can be opened in VS Code Dev Containers or GitHub Codespaces with a pre-configured .NET 10 environment.

## Included
- Official Microsoft .NET 10 base image (`mcr.microsoft.com/devcontainers/dotnet:10.0-noble`)
- C# Dev Kit, C# extension, EditorConfig extensions pre-installed
- `dotnet restore` runs automatically on container creation

## Testing
1. Open repo in VS Code → Reopen in Container
2. Verify `dotnet build` succeeds inside the container

Closes #