### PR TITLE
Update package validation baseline to 0.1.0-preview.6.0.2

### DIFF
--- a/src/Pure.RelationalSchema.Self.Schema/Pure.RelationalSchema.Self.Schema.csproj
+++ b/src/Pure.RelationalSchema.Self.Schema/Pure.RelationalSchema.Self.Schema.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <IsAotCompatible>true</IsAotCompatible>
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.1.0-preview.6.0.1</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.1.0-preview.6.0.2</PackageValidationBaselineVersion>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>Pure.RelationalSchema.Self.Schema</PackageId>


### PR DESCRIPTION
Bump `PackageValidationBaselineVersion` from `0.1.0-preview.6.0.1` to `0.1.0-preview.6.0.2` following the successful publish.